### PR TITLE
Update NotePreview.tsx to remove code blocks

### DIFF
--- a/src/components/NotePreview.tsx
+++ b/src/components/NotePreview.tsx
@@ -15,6 +15,8 @@ const NotePreview = ({ note }: Props) => {
 		const slicedContent = (await app.vault.cachedRead(note))
 			// remove frontmatter
 			.replace(/---.*?---/s, "")
+			// remove code blocks
+			.replace(/```.*?```/gs, "")
 			// restrict to chosen preview length
 			.substring(0, settings.previewLength);
 


### PR DESCRIPTION
Code blocks often cause errors on "On This Day" page, hence strip them out