### PR TITLE
Update CI Node versions and simplify settings rerendering

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
 
       - name: Install
         run: npm ci

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
 
       - name: Install
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,12 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
       - name: npm build
         run: |
           npm ci
@@ -26,7 +31,7 @@ jobs:
             dist/main.js
             dist/styles.css
       - name: Plugin release
-        uses: ncipollo/release-action@v1.13.0
+        uses: ncipollo/release-action@v1.21.0
         with:
           artifacts: "dist/**/*"
           generateReleaseNotes: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,6 @@ import {
 	DEFAULT_SETTINGS,
 	reduceTimeSpans,
 	Settings,
-	TimeSpan,
 	Unit,
 	VIEW_TYPE,
 } from "./constants";
@@ -132,7 +131,7 @@ export default class JournalReviewPlugin extends Plugin {
 					unit: (unit.endsWith("s") ? unit.slice(0, -1) : unit) as Unit,
 					recurring: false,
 				}),
-			) as TimeSpan[];
+			);
 		}
 
 		this.settings = Object.assign({}, DEFAULT_SETTINGS, parsedData);

--- a/src/settingsTab.ts
+++ b/src/settingsTab.ts
@@ -31,6 +31,10 @@ export class SettingsTab extends PluginSettingTab {
 	}
 
 	display(): void {
+		this.renderSettings();
+	}
+
+	private renderSettings(): void {
 		const { containerEl } = this;
 
 		containerEl.empty();
@@ -58,14 +62,13 @@ export class SettingsTab extends PluginSettingTab {
 						.addSlider((slider) =>
 							slider
 								.setLimits(1, getMaxTimeSpan(unit), 1)
-								.setDynamicTooltip()
 								.setValue(number)
 								.onChange(
 									debounce(
 										(value) => {
 											this.plugin.settings.timeSpans[index].number = value;
 											void this.plugin.saveSettings();
-											this.display();
+											this.renderSettings();
 										},
 										DEBOUNCE_DELAY,
 										true,
@@ -79,7 +82,7 @@ export class SettingsTab extends PluginSettingTab {
 								.onChange((value) => {
 									this.plugin.settings.timeSpans[index].unit = value as Unit;
 									void this.plugin.saveSettings();
-									this.display();
+									this.renderSettings();
 								}),
 						)
 						.addToggle((toggle) =>
@@ -88,7 +91,7 @@ export class SettingsTab extends PluginSettingTab {
 								.onChange((value) => {
 									this.plugin.settings.timeSpans[index].recurring = value;
 									void this.plugin.saveSettings();
-									this.display();
+									this.renderSettings();
 								})
 								.setTooltip("Recurring?"),
 						)
@@ -100,7 +103,7 @@ export class SettingsTab extends PluginSettingTab {
 								.onClick(() => {
 									this.plugin.settings.timeSpans.splice(index, 1);
 									void this.plugin.saveSettings();
-									this.display();
+									this.renderSettings();
 								}),
 						);
 				});
@@ -117,7 +120,7 @@ export class SettingsTab extends PluginSettingTab {
 							...defaultTimeSpans[0],
 						});
 						void this.plugin.saveSettings();
-						this.display();
+						this.renderSettings();
 					}),
 			);
 		});
@@ -132,19 +135,16 @@ export class SettingsTab extends PluginSettingTab {
 						"The number of days to include before and after the date being checked",
 					)
 					.addSlider((slider) =>
-						slider
-							.setDynamicTooltip()
-							.setValue(this.plugin.settings.dayMargin)
-							.onChange(
-								debounce(
-									(value) => {
-										this.plugin.settings.dayMargin = value;
-										void this.plugin.saveSettings();
-									},
-									DEBOUNCE_DELAY,
-									true,
-								),
+						slider.setValue(this.plugin.settings.dayMargin).onChange(
+							debounce(
+								(value) => {
+									this.plugin.settings.dayMargin = value;
+									void this.plugin.saveSettings();
+								},
+								DEBOUNCE_DELAY,
+								true,
 							),
+						),
 					);
 			})
 			.addSetting((setting) => {
@@ -218,7 +218,6 @@ export class SettingsTab extends PluginSettingTab {
 					.addSlider((slider) =>
 						slider
 							.setLimits(0, 1000, 10)
-							.setDynamicTooltip()
 							.setValue(this.plugin.settings.previewLength)
 							.onChange(
 								debounce(
@@ -290,7 +289,7 @@ export class SettingsTab extends PluginSettingTab {
 							.onChange((value) => {
 								this.plugin.settings.useCallout = value;
 								void this.plugin.saveSettings();
-								this.display();
+								this.renderSettings();
 							}),
 					);
 			});

--- a/src/styles.css
+++ b/src/styles.css
@@ -15,7 +15,7 @@
 	&.notes > li {
 		cursor: pointer;
 
-		&:has(.callout) {
+		& > .callout {
 			transition: transform 0.5s ease-out;
 
 			&:hover {


### PR DESCRIPTION
## Summary
- Bump GitHub Actions workflows to newer checkout/setup-node/release action versions and run CI on Node 24
- Refactor the settings tab to rerender through a dedicated helper instead of re-entering `display()` on every change
- Remove obsolete dynamic tooltip calls and tighten the callout selector in the stylesheet
- Clean up an unnecessary `TimeSpan` cast in settings parsing

## Testing
- Not run (not requested)